### PR TITLE
Add property [IsDisposed] for CudaContext & CudaRuntimeCompiler

### DIFF
--- a/ManagedCUDA/CudaContext.cs
+++ b/ManagedCUDA/CudaContext.cs
@@ -60,6 +60,7 @@ namespace ManagedCuda
 		protected int _deviceID;
 		/// <summary/>
 		protected bool disposed;
+		public bool IsDisposed { get { return disposed; } protected set { disposed = value; } }
 		private bool _contextOwner; //Indicates if this CudaContext instance created the wrapped cuda context and should be destroyed while disposing.
 
 		#region Constructors

--- a/NVRTC/CudaRuntimeCompiler.cs
+++ b/NVRTC/CudaRuntimeCompiler.cs
@@ -15,6 +15,9 @@ namespace ManagedCuda.NVRTC
 	{
 		nvrtcProgram _program;
 		bool disposed = false;
+
+		public bool IsDisposed { get { return disposed; } protected set { disposed = value; } }
+
 		nvrtcResult res;
         #region Contructors
         /// <summary>


### PR DESCRIPTION
Add property [IsDisposed] for CudaContext & CudaRuntimeCompiler,
to make it is possible to know whether the object is disposed.